### PR TITLE
Bootloader: fix L60 comment referencing a local-only pipeline file

### DIFF
--- a/projects/Bootloader/target/shared/bootloader/Stm32BootloaderHal.cpp
+++ b/projects/Bootloader/target/shared/bootloader/Stm32BootloaderHal.cpp
@@ -92,8 +92,7 @@ void Stm32BootloaderHal::SystemReset()
  *          restored it immediately. The ROM bootloader's autobaud has only
  *          ever been validated jumping from this project's 8 MHz HSE-direct
  *          clock — changing the pre-jump SYSCLK frequency is not a safe
- *          cleanup here. See .pipeline/REVIEW.md P2 #1 and LEDGER L60
- *          (closed won't-fix, hardware-proven) for the full account. The
+ *          cleanup here, even though it looks like an obvious fix. The
  *          bootloader's initial stack pointer and reset vector are taken
  *          from the first two words at 0x1FFF0000.
  */


### PR DESCRIPTION
The JumpToSystemMemory() warning comment pointed at .pipeline/REVIEW.md, which is local-only (git-excluded) and got cleared during a pipeline cleanup pass - the reference would dangle for anyone else cloning the repo. Made the comment self-contained instead of pointing at any .pipeline/ file.